### PR TITLE
Support flexible pluralization

### DIFF
--- a/preprocess.js
+++ b/preprocess.js
@@ -1,0 +1,48 @@
+function isNumberLike (key) {
+  return Number(key) == key // eslint-disable-line
+}
+
+function numericSort (a, b) {
+  return a - b
+}
+
+module.exports = function preprocessPlural (object) {
+  var generated = [
+    'if (o[n]) return o[n]'
+  ]
+
+  Object.keys(object).forEach(function (key) {
+    // We're only processing ranges
+    if (!/^-?\d+:-?\d+$/.test(key)) return
+
+    var split = key.split(':').map(Number).sort(numericSort)
+
+    // Put the boundaries of the range on the object so the fallbacks can read
+    // the ranges as numbers
+    object[split[0]] = object[split[1]] = object[key]
+
+    generated.push(
+      'if (n >= ' + split[0] + ' && n <= ' + split[1] + ') return o["' + key + '"]'
+    )
+  })
+
+  var numberKeys = Object.keys(object).filter(isNumberLike).sort(numericSort)
+
+  var max = numberKeys.pop()
+  var min = numberKeys.length ? numberKeys.shift() : max
+  object['*'] = object['*'] || object[max]
+  object['-*'] = object['-*'] || object[min]
+
+  // If the given count is not explicitly defined, use either the min or the max wildcard.
+  // Use the max wildcard if it's closest to the max value or in the middle.
+  // Otherwise, use the min wildcard.
+  generated.push(
+    'return ' + max + ' - n > n - ' + min + ' ? o["-*"] : o["*"]'
+  )
+
+  const pluralize = Function('o', 'n', generated.join('\n')) // eslint-disable-line
+
+  return function pluralizeCount (count) {
+    return pluralize(object, count)
+  }
+}

--- a/test.js
+++ b/test.js
@@ -3,87 +3,175 @@
 var test = require('tape')
 var Translate = require('./')
 
-var translate = Translate({
-  id: 'en_US',
-  values: {
-    PLAIN_STRING: 'hello',
-    PLURALIZED_SIMPLE: [
-      'Here are {{ count }}',
-      'Here is {{ count }}',
-      'And larger: {{ count }}'
-    ],
-
-    TEMPLATED: '{{foo}} {{   bar}} baz',
-
-    APPLE: [
-      'apples',
-      'apple',
-      'apples'
-    ],
-    COMPLEX: [
-      'No {{item}} left.',
-      'One {{item}} left.',
-      '{{count}} {{item}} left.'
-    ]
-  }
-})
-
 test('basic', t => {
-  t.equal(translate.id, 'en_US')
-  t.equal(translate('PLAIN_STRING'), 'hello')
+  var T = Translate({
+    id: 'en_US',
+    values: {
+      STRING: 'hi there',
+      TEMPLATED: '{{foo}} {{   bar}} baz',
+      TEMPLATED_COUNT: 'you can use count in templates too: {{count}}'
+    }
+  })
+
+  t.throws(() => T('NOT_FOUND'), /"NOT_FOUND" not found in dictionary "en_US"/)
+
+  t.equal(T('STRING'), 'hi there')
+  t.equal(T('TEMPLATED'), '{{foo}} {{   bar}} baz')
+  t.equal(T('TEMPLATED', {foo: 1, bar: 2}), '1 2 baz')
+  t.equal(T('TEMPLATED', {bar: 2}), '{{foo}} 2 baz')
+  t.equal(T('TEMPLATED_COUNT', {count: 333}), 'you can use count in templates too: 333')
   t.end()
 })
 
-test('not found', t => {
-  t.throws(() => translate('NOT_FOUND'), /"NOT_FOUND" not found/)
-  t.end()
-})
+test('advanced pluralization', t => {
+  var T = Translate({
+    values: {
+      PLURAL: {
+        '-*': 'And smaller: {{count}}.',
+        '-3:-6': 'Range -3:-6',
+        0: 'Here are {{ count }}',
+        1: 'Here is {{ count }}',
+        '5:10': 'Five to 10 {{count}}',
+        '*': 'And larger: {{ count }}'
+      }
+    }
+  })
 
-test('pluralized simple', t => {
-  t.throws(() => translate('PLURALIZED_SIMPLE', {}), /pluralized/)
-  t.throws(() => translate('PLURALIZED_SIMPLE', {count: 'not a number'}), /pluralized/)
+  t.throws(() => T('PLURAL', {}), /pluralized/)
+  t.throws(() => T('PLURAL', {count: 'not a number'}), /pluralized/)
 
-  t.equal(translate('PLURALIZED_SIMPLE', {count: 0}), 'Here are 0')
-  t.equal(translate('PLURALIZED_SIMPLE', {count: 1}), 'Here is 1')
-  t.equal(translate('PLURALIZED_SIMPLE', {count: 2}), 'And larger: 2')
-  t.equal(translate('PLURALIZED_SIMPLE', {count: 3}), 'And larger: 3')
-  t.equal(translate('PLURALIZED_SIMPLE', {count: 999}), 'And larger: 999')
-  t.equal(translate('PLURALIZED_SIMPLE', {count: 0}), 'Here are 0')
-  t.equal(translate('PLURALIZED_SIMPLE', {count: -1}), 'Here is -1')
-  t.equal(translate('PLURALIZED_SIMPLE', {count: -2}), 'And larger: -2')
-  t.equal(translate('PLURALIZED_SIMPLE', {count: -3}), 'And larger: -3')
-  t.end()
-})
-
-test('templates', t => {
-  t.equal(translate('TEMPLATED', {foo: 1, bar: 2}), '1 2 baz')
-  t.equal(translate('TEMPLATED', {bar: 2}), '{{foo}} 2 baz')
+  t.equal(T('PLURAL', {count: 0}), 'Here are 0')
+  t.equal(T('PLURAL', {count: 1}), 'Here is 1')
+  t.equal(T('PLURAL', {count: 2}), 'And larger: 2')
+  t.equal(T('PLURAL', {count: 999}), 'And larger: 999')
+  t.equal(T('PLURAL', {count: 4}), 'And larger: 4')
+  for (var i = 5; i <= 10; i++) {
+    t.equal(T('PLURAL', {count: i}), 'Five to 10 ' + i)
+  }
+  t.equal(T('PLURAL', {count: 11}), 'And larger: 11')
+  t.equal(T('PLURAL', {count: -2}), 'And smaller: -2.')
+  for (var j = -3; j >= -6; j--) {
+    t.equal(T('PLURAL', {count: j}), 'Range -3:-6')
+  }
+  t.equal(T('PLURAL', {count: -7}), 'And smaller: -7.')
   t.end()
 })
 
 test('complex', t => {
+  var T = Translate({
+    values: {
+      APPLE: [
+        'apples',
+        'apple',
+        'apples'
+      ],
+      COMPLEX: {
+        0: 'No {{item}} left.',
+        1: 'One {{item}} left.',
+        '2:10': 'A good amount of {{item}} left.',
+        '*': 'Way too many {{item}} left.'
+      }
+    }
+  })
+
   t.equal(
-    translate('COMPLEX', {
-      item: translate('APPLE', {count: 0}),
+    T('COMPLEX', {
+      item: T('APPLE', {count: 0}),
       count: 0
     }),
     'No apples left.'
   )
 
   t.equal(
-    translate('COMPLEX', {
-      item: translate('APPLE', {count: 1}),
+    T('COMPLEX', {
+      item: T('APPLE', {count: 1}),
       count: 1
     }),
     'One apple left.'
   )
 
   t.equal(
-    translate('COMPLEX', {
-      item: translate('APPLE', {count: 999}),
-      count: 999
+    T('COMPLEX', {
+      item: T('APPLE', {count: 4}),
+      count: 4
     }),
-    '999 apples left.'
+    'A good amount of apples left.'
   )
+
+  t.equal(
+    T('COMPLEX', {
+      item: T('APPLE', {count: 14}),
+      count: 14
+    }),
+    'Way too many apples left.'
+  )
+  t.end()
+})
+
+test('holes with wildcards choose the closest', t => {
+  const T = Translate({
+    values: {
+      HOLES: {
+        '-*': 'min',
+        '-3:-2': 'neg range',
+        '3': 'three',
+        '*': 'max'
+      }
+    }
+  })
+
+  t.equal(T('HOLES', {count: -4}), 'min')
+  t.equal(T('HOLES', {count: -3}), 'neg range')
+  t.equal(T('HOLES', {count: -2}), 'neg range')
+  t.equal(T('HOLES', {count: -1}), 'min')
+  t.equal(T('HOLES', {count: 0}), 'max')
+  t.equal(T('HOLES', {count: 1}), 'max')
+  t.equal(T('HOLES', {count: 2}), 'max')
+  t.equal(T('HOLES', {count: 3}), 'three')
+  t.equal(T('HOLES', {count: 4}), 'max')
+  t.end()
+})
+
+test('edgecases', t => {
+  var T = Translate({
+    values: {
+      SAME_MIN_MAX: {
+        0: 'hi'
+      },
+      MIN_0: {
+        0: 'min0',
+        1: 'max1'
+      },
+      OVERLAPPING_RANGES: {
+        '1:3': 'one three',
+        '3:5': 'three five'
+      },
+      WILDCARDS: {
+        '-*': 'min',
+        1: 'mid',
+        '*': 'max'
+      }
+    }
+  })
+  t.equal(T('SAME_MIN_MAX', {count: -1}), 'hi')
+  t.equal(T('SAME_MIN_MAX', {count: 0}), 'hi')
+  t.equal(T('SAME_MIN_MAX', {count: 1}), 'hi')
+
+  t.equal(T('MIN_0', {count: -1}), 'min0')
+  t.equal(T('MIN_0', {count: 0}), 'min0')
+  t.equal(T('MIN_0', {count: 1}), 'max1')
+  t.equal(T('MIN_0', {count: 2}), 'max1')
+
+  t.equal(T('OVERLAPPING_RANGES', {count: 0}), 'one three')
+  t.equal(T('OVERLAPPING_RANGES', {count: 1}), 'one three')
+  t.equal(T('OVERLAPPING_RANGES', {count: 2}), 'one three')
+  t.equal(T('OVERLAPPING_RANGES', {count: 3}), 'three five')
+  t.equal(T('OVERLAPPING_RANGES', {count: 4}), 'three five')
+  t.equal(T('OVERLAPPING_RANGES', {count: 5}), 'three five')
+  t.equal(T('OVERLAPPING_RANGES', {count: 6}), 'three five')
+
+  t.equal(T('WILDCARDS', {count: 0}), 'min')
+  t.equal(T('WILDCARDS', {count: 1}), 'mid')
+  t.equal(T('WILDCARDS', {count: 2}), 'max')
   t.end()
 })


### PR DESCRIPTION
Ref #1. @gertsonderby informed me of how complicated pluralization really is: any range needs to be able to have its own translation.

That's now supported. We're still below 800b payload.

Ranges (inclusive), negative wildcards, and positive wildcards are now supported. A plural value is now just an object with allowed number keys, wildcard keys, and range keys. This means that the array syntax still works.

```js
    PLURALIZED_COMPLEX: {
      '-*': 'Negative fallback with {{count}}.',
      '-3:-6': 'Range -3:-6',
      0: 'Here are {{ count }}',
      1: 'Here is {{ count }}',
      '5:10': 'Five to 10 {{count}}',
      '*': 'And larger: {{ count }}'
    },
```

This complex value is lazily generated into a function at runtime, only the first time the translation key is requested. It simply becomes something like this:

```js
function anonymous(o,n
/**/) {
if (o[n]) return o[n]
if (n >= -6 && n <= -3) return o["-3:-6"]
if (n >= 5 && n <= 10) return o["5:10"]
return n < 0 ? o["-*"] : o["*"]
}
```

The wildcards '\*' and '-\*' default to the largest and smallest values given.